### PR TITLE
Bad GitHub link - Updated Link to Project Page

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     <h2 id="GitHub"><b>May 8, 2015</b> XStream hosted at GitHub</h2>
 
       <p>Codehaus has been XStream's home for more than a decade. Now is the time for a new home at
-      <a href="http://x-stream.github.io/)">GitHub</a>, since Codehaus is shut down within the next view days.</p>
+      <a href="https://github.com/x-stream/xstream">GitHub</a>, since Codehaus is shut down within the next view days.</p>
 
       <p>The XStream committers want to thank Codehaus for their marvelous service over all those years.</p>
 


### PR DESCRIPTION
Link was pointing to "http://x-stream.github.io/)" which is invalid due to extra ")". amended it to "https://github.com/x-stream/xstream" where project binaries are hosted.
