### PR TITLE
Fix link to CVE-2021-29505 details

### DIFF
--- a/1.4.17/changes.html
+++ b/1.4.17/changes.html
@@ -63,7 +63,7 @@
 	<p>Released May 13, 2021.</p>
 
 	<p class="highlight">This maintenance release addresses the security vulnerability
-	<a href="CVE-2020-26258.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
+	<a href="CVE-2021-29505.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
 	security framework.</p>
 
 	<h2>Stream compatibility</h2>

--- a/1.4.17/index.html
+++ b/1.4.17/index.html
@@ -99,7 +99,7 @@
     <h2 id="release"><b>May 13, 2021</b> XStream 1.4.17 released</h2>
 
 	<p class="highlight">TThis maintenance release addresses the security vulnerability
-	<a href="CVE-2020-26258.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
+	<a href="CVE-2021-29505.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
 	security framework.</p>
 
 	<p>View the complete <a href="changes.html">change log</a> and <a href="download.html">download</a>.</p>

--- a/1.4.17/news.html
+++ b/1.4.17/news.html
@@ -42,7 +42,7 @@
     <h2 id="1.4.17"><b>May 13, 2021</b> XStream 1.4.17 released</h2>
 
 	<p class="highlight">This maintenance release addresses the security vulnerability
-	<a href="CVE-2020-26258.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
+	<a href="CVE-2021-29505.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
 	security framework.</p>
 
 	<p>View the complete <a href="changes.html">change log</a> and <a href="download.html">download</a>.</p>

--- a/changes.html
+++ b/changes.html
@@ -63,7 +63,7 @@
 	<p>Released May 13, 2021.</p>
 
 	<p class="highlight">This maintenance release addresses the security vulnerability
-	<a href="CVE-2020-26258.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
+	<a href="CVE-2021-29505.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
 	security framework.</p>
 
 	<h2>Stream compatibility</h2>

--- a/index.html
+++ b/index.html
@@ -98,8 +98,8 @@
 
     <h2 id="release"><b>May 13, 2021</b> XStream 1.4.17 released</h2>
 
-	<p class="highlight">TThis maintenance release addresses the security vulnerability
-	<a href="CVE-2020-26258.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
+	<p class="highlight">This maintenance release addresses the security vulnerability
+	<a href="CVE-2021-29505.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
 	security framework.</p>
 
 	<p>View the complete <a href="changes.html">change log</a> and <a href="download.html">download</a>.</p>

--- a/news.html
+++ b/news.html
@@ -42,7 +42,7 @@
     <h2 id="1.4.17"><b>May 13, 2021</b> XStream 1.4.17 released</h2>
 
 	<p class="highlight">This maintenance release addresses the security vulnerability
-	<a href="CVE-2020-26258.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
+	<a href="CVE-2021-29505.html">CVE-2021-29505</a>, when unmarshalling with XStream instances using an uninitialized
 	security framework.</p>
 
 	<p>View the complete <a href="changes.html">change log</a> and <a href="download.html">download</a>.</p>


### PR DESCRIPTION
Thanks for the new release!
This PR corrects the link to the CVE-2021-29505 details.