### PR TITLE
Fix encoding of < > in CVE-2022-40151 page

### DIFF
--- a/CVE-2022-40151.html
+++ b/CVE-2022-40151.html
@@ -60,11 +60,11 @@
     following code snippet and unmarshal it with XStream:</p>
 <div class="Source Java"><pre>String xml = new String();
         int i = 0;
-        for( ; i &lt 10000; ++i) {
-            xml += "<set>";
+        for( ; i &lt; 10000; ++i) {
+            xml += "&lt;set&gt;";
         }
         for( ; i > 0; --i) {
-            xml += "</set>";
+            xml += "&lt;/set&gt;";
         }
 </pre></div>
 <div class="Source Java"><pre>XStream xstream = new XStream();


### PR DESCRIPTION
The example code was not correctly displayed (at least with Firefox).